### PR TITLE
Make example docs dependent on python files

### DIFF
--- a/docs/basic_examples.rst
+++ b/docs/basic_examples.rst
@@ -5,49 +5,8 @@ dummy.py
 --------
 This is the most basic and simple example which generates randomized 256x256 images as fake detector events showing up as ``evt['photonPixelDetectors']['CCD']`` for virtual events created at a repetition rate of 10 Hz:
 
-::
-
-   # Import analysis/plotting modules
-   import analysis.event
-   import plotting.image
-   import numpy as np
-   
-   # Set new random seed
-   np.random.seed()
-
-   # Specify the facility
-   state = {}
-   state['Facility'] = 'Dummy'
-
-   # Create a dummy facility
-   state['Dummy'] = {
-       # The event repetition rate of the dummy facility [Hz]
-       'Repetition Rate' : 10,
-       # Dictionary of data sources
-       'Data Sources': {
-           # The name of the data source. 
-           'CCD': {
-               # A function that will generate the data for every event
-               'data': lambda: np.random.rand(256,256),
-               # The units to be used
-               'unit': 'ADU',     
-               # The name of the category for this data source.
-               # All data sources are aggregated by type, which is the key
-               # used when asking for them in the analysis code.
-               'type': 'photonPixelDetectors'
-           }        
-       }
-   }
-
-   # This function is called for every single event
-   # following the given recipy of analysis
-   def onEvent(evt):
-
-       # Processin rate [Hz]
-       analysis.event.printProcessingRate()
-
-       # Visualize detector image
-       plotting.image.plotImage(evt['photonPixelDetectors']['CCD'])
+.. literalinclude:: ../examples/basic/dummy.py
+                       :language: python
 
 Notice that facility and data source is defined using the ``state`` variable. For every event, the current processing rate is printed and an image with the current virtual detector image is sent to the interface. Running this example in the backend (``hummingbird.py -b examples/basic/dummy.py``) we can start the frontend (``hummingbird.py -i``) in a separate shell (or even on a separate machine) and connect it to the backend by clicking on the left-most button:
 
@@ -68,49 +27,8 @@ simulation.py
 -------------
 For the next example, we replace the random detector images with CCD images that simulate diffraction from an object produced at a given hit rate (here 50%):
 
-::
-
-   # Import analysis/plotting/simulation modules
-   import analysis.event
-   import plotting.image
-   import simulation.base
-
-   # Simulate diffraction data  
-   sim = simulation.base.Simulation()
-   sim.hitrate = 0.5
-   sim.sigma = 1
-
-   # Specify the facility
-   state = {}
-   state['Facility'] = 'Dummy'
-
-   # Create a dummy facility
-   state['Dummy'] = {
-       # The event repetition rate of the dummy facility [Hz]
-       'Repetition Rate' : 10,
-       # Specify simulation
-       'Simulation': sim,
-       # Dictionary of data sources
-       'Data Sources': {
-           # Data from a virtual diffraction detector
-           'CCD': {
-               # Fetch diffraction data from the simulation
-               'data': sim.get_pattern,
-               'unit': 'ADU',
-               'type': 'photonPixelDetectors'
-           }
-       }
-   }
-
-   # This function is called for every single event
-   # following the given recipy of analysis
-   def onEvent(evt):
-
-      # Processing rate [Hz]
-      analysis.event.printProcessingRate()
-      
-      # Visualize detector image
-      plotting.image.plotImage(evt['photonPixelDetectors']['CCD'], vmin=-10, vmax=40)
+.. literalinclude:: ../examples/basic/simulation.py
+                       :language: python
 
 Following the same procedure as for ``dummy.py`` we can follow the hits (left) and misses (right) show up in the interface:
       
@@ -126,70 +44,8 @@ detector.py
 
 In order to add more analysis of the detector we print some statistics, count the number of photons and send a history of the photon counts and per-event detector histograms along with the CCD image:
 
-::
-
-   # Import analysis/plotting/simulation modules
-   import analysis.event
-   import analysis.pixel_detector
-   import plotting.line
-   import plotting.image
-   import simulation.base
-
-   # Simulate diffraction data  
-   sim = simulation.base.Simulation()
-   sim.hitrate = 0.5
-   sim.sigma = 1
-
-   # Specify the facility
-   state = {}
-   state['Facility'] = 'Dummy'
-
-   # Create a dummy facility
-   state['Dummy'] = {
-       # The event repetition rate of the dummy facility [Hz]
-       'Repetition Rate' : 10,
-       # Specify simulation
-       'Simulation': sim,
-       # Dictionary of data sources
-       'Data Sources': {
-           # Data from a virtual diffraction detector
-           'CCD': {
-               # Fetch diffraction data from the simulation
-               'data': sim.get_pattern,
-               'unit': 'ADU',
-               'type': 'photonPixelDetectors'
-           }
-       }
-   }
-
-   # Configuration for histogram plot
-   histogramCCD = {
-       'hmin': -10,
-       'hmax': 100,
-       'bins': 200,
-       'label': "Nr of photons",
-       'history': 200}
-
-   # This function is called for every single event
-   # following the given recipy of analysis
-   def onEvent(evt):
-
-       # Processing rate [Hz]
-       analysis.event.printProcessingRate()
-
-       # Detector statistics
-       analysis.pixel_detector.printStatistics(evt["photonPixelDetectors"])
-
-       # Count Nr. of Photons
-       analysis.pixel_detector.totalNrPhotons(evt, "photonPixelDetectors", "CCD")
-       plotting.line.plotHistory(evt["analysis"]["nrPhotons - CCD"],
-                                 label='Nr of photons / frame', history=50)
-
-       # Detector histogram
-       plotting.line.plotHistogram(evt["photonPixelDetectors"]["CCD"], **histogramCCD)
-       
-       # Detector images
-       plotting.image.plotImage(evt["photonPixelDetectors"]["CCD"])
+.. literalinclude:: ../examples/basic/detector.py
+                       :language: python
 
 In the interface, we can now open a new line plot (3rd button from the left) and display the history of the photon counts by subscribing to the ``History(analysis/nrPhotons - CCD)`` data source:
 
@@ -212,69 +68,8 @@ hitfinding.py
 
 In the next example, we add htifinding to our analysis pipeline. We use a simply lit pixel counter given thresholds for the definition of a photon (``aduThreshold=10``) and for the definition of a hit (``hitscoreThreshold=100``):
 
-::
-
-   # Import analysis/plotting/simulation modules
-   import analysis.event
-   import analysis.hitfinding
-   import plotting.image
-   import plotting.line
-   import simulation.base
-
-   # Simulate diffraction data  
-   sim = simulation.base.Simulation()
-   sim.hitrate = 0.5
-   sim.sigma = 1
-
-   # Specify the facility
-   state = {}
-   state['Facility'] = 'Dummy'
-
-   # Create a dummy facility
-   state['Dummy'] = {
-       # The event repetition rate of the dummy facility [Hz]
-       'Repetition Rate' : 10,
-       # Specify simulation
-       'Simulation': sim,
-       # Dictionary of data sources
-       'Data Sources': {
-            # Data from a virtual diffraction detector
-            'CCD': {
-                # Fetch diffraction data from the simulation
-                'data': sim.get_pattern,
-                'unit': 'ADU',
-                'type': 'photonPixelDetectors'
-            }
-       }
-   }
-
-   # This function is called for every single event
-   # following the given recipy of analysis
-   def onEvent(evt):
-
-       # Processing rate [Hz]
-       analysis.event.printProcessingRate()
-
-       # Simple hit finding (counting the number of lit pixels)
-       analysis.hitfinding.countLitPixels(evt, "photonPixelDetectors", "CCD",
-                                          aduThreshold=10, hitscoreThreshold=100)
-
-       # Extract boolean (hit or miss)
-       hit = evt["analysis"]["isHit - CCD"].data
-
-       # Compute the hitrate
-       analysis.hitfinding.hitrate(evt, hit, history=1000)
-
-       # Plot the hitscore
-       plotting.line.plotHistory(evt["analysis"]["hitscore - CCD"], label='Nr. of lit pixels')
-       
-       # Plot the hitrate
-       plotting.line.plotHistory(evt["analysis"]["hitrate"], label='Hit rate [%]')
-   
-       # Visualize detector image of hits
-       if hit:
-           plotting.image.plotImage(evt["photonPixelDetectors"]["CCD"], vmin=-10, vmax=40)
-
+.. literalinclude:: ../examples/basic/hitfinding.py
+                       :language: python
 
 As compared to previos examples, we are plotting the CCD image only for hits. We are also sending history plots of hitscore and hitrate. The former can be very useful for finding the correct thresholds. When changing the threshold in the configuration file, there is no need to restart the backend. We can simply reload the configuration using the reload button (right-most button). Having all plots connected, the frontend looks like this:
 
@@ -288,101 +83,8 @@ correlation.py
 --------------
 In the last example, we show how it is possible to correlate and compare different parameters. Therefore, we first add more virtual data to our simulation: randomzied pulse energies and (x,y) injector positions. Along with plotting the history of pulse energies and plotting the correlation of pulse energy vs. hitscore as a scatter plot, we populate a map of averaged hitrates as a function the (x,y) injector position tuple:
 
-::
-
-   # Import analysis/plotting/simulation modules
-   import analysis.event
-   import analysis.hitfinding
-   import plotting.line
-   import plotting.image
-   import plotting.correlation
-   import simulation.base
-
-   # Simulate diffraction data  
-   sim = simulation.base.Simulation()
-   sim.hitrate = 0.5
-   sim.sigma = 1
-
-   # Specify the facility
-   state = {}
-   state['Facility'] = 'Dummy'
-
-   # Create a dummy facility
-   state['Dummy'] = {
-       # The event repetition rate of the dummy facility [Hz]
-       'Repetition Rate' : 10,
-       # Specify simulation
-       'Simulation': sim,
-       # Dictionary of data sources
-       'Data Sources': {
-           # Data from a virtual diffraction detector
-           'CCD': {
-               # Fetch diffraction data from the simulation
-               'data': sim.get_pattern,
-               'unit': 'ADU',
-               'type': 'photonPixelDetectors'
-           },
-           # Data from a virutal pulse energy detector
-           'pulseEnergy': {
-               # Fetch pulse energy valus from the simulation
-               'data': sim.get_pulse_energy,
-               'unit': 'J',
-               'type': 'pulseEnergies'
-           },
-           # Data from a virutal injector motor
-           'injectorX': {
-               # Fetch injector motor valus (x) from the simulation
-               'data': sim.get_injector_x,
-               'unit': 'm',
-               'type': 'parameters'
-           },
-           # Data from a virutal injector motor
-           'injectorY': {
-               # Fetch injector motor valus (y) from the simulation
-               'data': sim.get_injector_y,
-               'unit': 'm',
-               'type': 'parameters'
-           }
-       }
-   }
-
-   # Configuration for hitrate meanmap plot
-   hitmapParams = {
-       'xmin':0,
-       'xmax':1e-6,
-       'ymin':0,
-       'ymax':1e-6,
-       'xbins':10,
-       'ybins':10
-   }
-   
-   # This function is called for every single event
-   # following the given recipy of analysis
-   def onEvent(evt):
-
-       # Processing rate [Hz]
-       analysis.event.printProcessingRate()
-
-       # Simple hit finding (counting the number of lit pixels)
-       analysis.hitfinding.countLitPixels(evt, "photonPixelDetectors", "CCD",
-                                          aduThreshold=10, hitscoreThreshold=100)
-
-       # Extract boolean (hit or miss)
-       hit = evt["analysis"]["isHit - CCD"].data
-       
-       # Compute the hitrate
-       analysis.hitfinding.hitrate(evt, hit, history=1000)
-
-       # Plot history of pulse energy
-       plotting.line.plotHistory(evt['pulseEnergies']['pulseEnergy'])
-       
-       # Plot scatter of pulse energy vs. hitscore
-       plotting.correlation.plotScatter(evt['pulseEnergies']['pulseEnergy'],
-                                        evt["analysis"]["hitscore - CCD"])
-       
-       # Plot heat map of hitrate as function of injector position
-       plotting.correlation.plotMeanMap(evt["parameters"]['injectorX'], evt["parameters"]['injectorY'],
-                                        evt["analysis"]["hitrate"].data, plotid='hitrateMeanMap')
+.. literalinclude:: ../examples/basic/correlation.py
+                       :language: python
 
 In the interface, these plots look like this:
                                         

--- a/docs/lcls_examples.rst
+++ b/docs/lcls_examples.rst
@@ -22,7 +22,7 @@ Hit finding of mimivirus
 
 This example is based on diffraction data from mimivirus (cite) published in the |cxidb| (entry 30).
 In order to run this example, it is necessary to download raw data files (XTC format) for a dark run (73) and a diffraction run (92)
-and put it inside a directory `XTC_DIR`.
+and put it inside a directory for XTC files.
 
 .. |cxidb| raw:: html
                  
@@ -33,97 +33,18 @@ mimi_dark.py
 
 First, we need to get the average dark image running the backend with the following configuration:
 
-::
-
-   import analysis.event
-   import plotting.image
-   import h5py
-
-   state = {}
-   state['Facility'] = 'LCLS'
-   state['LCLS/DataSource'] = 'exp=amo15010:dir=XTC_DIR:run=73'
-
-   dark = 0.
-   event_number = 0
-
-   def onEvent(evt):
-
-       global dark, event_number
-       dark  += evt['photonPixelDetectors']['pnccdBackfullFrame'].data
-       event_number += 1
-
-   def end_of_run():
-       print "Saving average dark image to dark_run73.h5"
-       with h5py.File('dark_run73.h5', 'w') as f:
-           f['mean']  = dark  / event_number
+.. literalinclude:: ../examples/lcls/mimi_dark.py
+                    :language: python
 
 This will save the average dark in an HDF5 file named ``dark_run73.h5``.
-Note that `XTC_DIR` should be replaced with the location of the raw data files.
 
 mimi_hits.py
 ------------
 
 With the average dark image ready, we can run with the following configuration:
 
-::
-
-   import analysis.event
-   import analysis.hitfinding
-   import analysis.pixel_detector
-   import plotting.line
-   import plotting.image
-   import utils.reader
-
-   state = {}
-   state['Facility'] = 'LCLS'
-   state['LCLS/DataSource'] = 'exp=amo15010:dir=XTC_DIR:run=92'
-   state['indexing'] = True
-   state['index_offset'] = 2250
-
-   # Load dark frame from file
-   dark = utils.reader.H5Reader('dark_run73.h5', 'mean').dataset
-
-   # Parameters
-   adu_photon = 12
-   threshold  = 90000
-   hist_min  = 5
-   hist_max  = 35
-   hist_bins = 40
-
-   def onEvent(evt):
-
-       # Processing rate
-       analysis.event.printProcessingRate()
-
-       try:
-           evt['photonPixelDetectors']['pnccdBackfullFrame']
-       except KeyError:
-           return 
-
-       # Dark calibration
-       analysis.pixel_detector.subtractImage(evt, 'photonPixelDetectors', 'pnccdBackfullFrame', 
-                                             dark, outkey='pnccdBackSubtracted')
-                                          
-       # Common mode correction
-       analysis.pixel_detector.commonModePNCCD(evt, 'analysis', 'pnccdBackSubtracted', 
-                                               outkey='pnccdBackCorrected')
-
-       # Plot back detector histogram (to figure out ADU/photon -> aduThreshold)
-       plotting.line.plotHistogram(evt['analysis']['pnccdBackCorrected'], 
-                                   hmin=hist_min, hmax=hist_max, bins=hist_bins, vline=adu_photon)
-
-       # Hitfinding
-       analysis.hitfinding.countLitPixels(evt, evt['analysis']['pnccdBackCorrected'], 
-                                          aduThreshold=adu_photon, hitscoreThreshold=threshold)
-
-       # Plot hitscore (to monitor hitfinder -> hitscoreThreshold)
-       plotting.line.plotHistory(evt['analysis']['litpixel: hitscore'], hline=threshold)
-
-       # Plot back detector image for hits only
-       if bool(evt['analysis']['litpixel: isHit'].data):
-           plotting.image.plotImage(evt['analysis']['pnccdBackCorrected'], 
-                                    log=True, name='pnccdBack - only hits')
-   
+.. literalinclude:: ../examples/lcls/mimi_hits.py
+                    :language: python
 
 This performs detector correction (subtraction of average dark, common-mode), does hit finding based on a simple lit pixel counter and sends off detector images of hits as well as diagnostic plots for tuning the hit finder to the frontend.
 


### PR DESCRIPTION
It should be possible to have the documentation of the examples to be dependent on the actual example files. This avoids out-dated example docs and ugly copy-pasting. 