### PR TITLE
Cmdlineargs

### DIFF
--- a/src/backend/lcls.py
+++ b/src/backend/lcls.py
@@ -16,35 +16,36 @@ from backend import Worker
 import ipc
 from hummingbird import parse_cmdline_args
 
-def add_cmdline_args(parser):
-    global argparser
-    argparser = parser
-    group = argparser.add_argument_group('LCLS', 'Options for the LCLS event translator')
+_argparser = None
+def add_cmdline_args():
+    global _argparser
+    from utils.cmdline_args import argparser
+    _argparser = argparser
+    group = _argparser.add_argument_group('LCLS', 'Options for the LCLS event translator')
     group.add_argument('--lcls-run-number', metavar='lcls_run_number', nargs='?',
-                       help="run number",
-                       type=int)
+                        help="run number",
+                        type=int)
     group.add_argument('--lcls-number-of-frames', metavar='lcls_number_of_frames', nargs='?',
-                       help="number of frames to be processed",
-                       type=int)
+                        help="number of frames to be processed",
+                        type=int)
     
     # ADUthreshold for offline analysis
-    group.add_argument('--ADUthreshold', metavar='ADUthreshold', nargs='?',
-                       help="ADU threshold",
-                       type=int)
+    #group.add_argument('--ADUthreshold', metavar='ADUthreshold', nargs='?',
+    #                    help="ADU threshold",
+    #                    type=int)
     # Hitscore threshold for offline analysis
-    group.add_argument('--hitscore-thr', metavar='hitscore_thr', nargs='?',
-                       help="Hitscore threshold",
-                       type=int)
+    #group.add_argument('--hitscore-thr', metavar='hitscore_thr', nargs='?',
+    #                    help="Hitscore threshold",
+    #                    type=int)
     # Output directory for offline analysis
-    group.add_argument('--out-dir', metavar='out_dir', nargs='?',
-                       help="Output directory",
-                       type=str)
+    #group.add_argument('--out-dir', metavar='out_dir', nargs='?',
+    #                    help="Output directory",
+    #                    type=str)
     # Reduce output from offline analysis
-    group.add_argument('--reduced-output',
-                       help="Write only very few data to output file",
-                       action='store_true')
+    #group.add_argument('--reduced-output',
+    #                    help="Write only very few data to output file",
+    #                    action='store_true')
     
-    return argparser
     
 class LCLSTranslator(object):
     """Translate between LCLS events and Hummingbird ones"""
@@ -80,7 +81,7 @@ class LCLSTranslator(object):
             raise ValueError("You need to set the '[LCLS][DataSource]'"
                              " in the configuration")
         
-        cmdline_args = parse_cmdline_args()
+        cmdline_args = _argparser.parse_args()
         self.N = cmdline_args.lcls_number_of_frames          
         if cmdline_args.lcls_run_number is not None:
             dsrc += ":run=%i" % cmdline_args.lcls_run_number

--- a/src/ipc/zmqserver.py
+++ b/src/ipc/zmqserver.py
@@ -14,7 +14,7 @@ import hashlib
 import ipc.mpi
 import backend.worker
 import logging
-from utils.cmdline_args import options
+from utils.cmdline_args import argparser as _argparser
 
 eventLimit = 125
 
@@ -25,7 +25,7 @@ class ZmqServer(object):
         self._subscribed = set()
         self.reloadmaster = False
         
-        self._batch_mode = bool(options().batch_mode)
+        self._batch_mode = bool(_argparser.parse_args().batch_mode)
         if self._batch_mode:
             return
 

--- a/src/utils/cmdline_args.py
+++ b/src/utils/cmdline_args.py
@@ -1,0 +1,46 @@
+import sys
+import logging 
+import argparse
+
+argparser = argparse.ArgumentParser(description='Hummingbird - '
+                                    'Monitoring and Analysing FXI experiments.')
+_group = argparser.add_mutually_exclusive_group()
+_group.add_argument("-i", "--interface",
+                    help="start the control and display interface",
+                    action="store_true")
+_group.add_argument('-b', '--backend', metavar='conf.py',
+                    type=str, help="start the backend with "
+                    "given configuration file", nargs='?', const=True)
+_group.add_argument('-r', '--reload', help='reloads the backend',
+                    action='store_true')
+argparser.add_argument('-m', '--batch-mode', help='running only backend without any interactive front end',
+                       action='store_true')
+argparser.add_argument("-p", "--port",
+                       type=int, default=13131, help="overwrites the port, defaults to 13131")
+argparser.add_argument("-v", "--verbose", help="increase output verbosity",
+                       action="store_true")
+argparser.add_argument("-d", "--debug", help="output debug messages",
+                       action="store_true")
+argparser.add_argument("--profile", help="generate and output profiling information",
+                       action="store_true")
+argparser.add_argument("--no-restore", help="no restoring of Qsettings",
+                       action="store_false")
+
+# Add LCLS-specific arguments to argparser
+try:
+    from backend.lcls import add_cmdline_args
+    add_cmdline_args()
+except ImportError:
+    pass
+
+_config_argument_group = None
+_config_file_arguments_added = []
+def add_config_file_argument(*args, **kwargs):
+    global _config_argument_group
+    if _config_argument_group is None:
+        _config_argument_group = argparser.add_argument_group('Configuration file', 'Configuration file specific options')
+    # Avoid that arguments get added twice when reloading the configuration file
+    added = any([(args == args_added) and all(set(kwargs.items()) & set(kwargs_added.items())) for args_added,kwargs_added in _config_file_arguments_added])
+    if not added:
+        _config_argument_group.add_argument(*args, **kwargs)
+        _config_file_arguments_added.append((args, kwargs))


### PR DESCRIPTION
Command line arguments are now handled in a separate file. Command line arguments that are specific for a configuration file can be added by calling function add_config_file_argument defined in utils.cmdline_args. The help messages for the newly added configurationfile-specific command line arguments will appear when executing for example:
$ hummingbird.py -b my_conf.py --help