### PR TITLE
Use tornado.ioloop

### DIFF
--- a/src/ipc/zmqserver.py
+++ b/src/ipc/zmqserver.py
@@ -18,16 +18,13 @@ import backend.worker
 import logging
 from utils.cmdline_args import argparser as _argparser
 
+
 eventLimit = 125
 
-# Tornado 5 changed the behaviour of IOLoop.instance() such that
-# is now returns a new thread local IOLoop instead of the main
-# thread IOLoop. So we need this global variable to tell the thread
-# the correct IOLoop to start.
-# http://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.instance
-#
-# IOLoop.instance() is depricated in Tornado 5.0. Use IOLoop.current() instead.
+# `IOLoop.current()` returns a thread local `IOLoop`. So we need this 
+# global variable to tell the thread the correct `IOLoop` to start.
 ioloop = tornado.ioloop.IOLoop.current()
+
 
 class ZmqServer(object):
     """Implements the server that broadcasts the results from the backend.
@@ -84,7 +81,6 @@ class ZmqServer(object):
         # Make sure the program exists even when the thread exists
         t.daemon = True
         t.start()
-
 
     def _send_array(self, array, flags=0, copy=True, track=False):
         """Send a numpy array with metadata"""

--- a/src/ipc/zmqserver.py
+++ b/src/ipc/zmqserver.py
@@ -8,6 +8,7 @@ from __future__ import print_function, absolute_import # Compatibility with pyth
 import zmq
 import zmq.eventloop
 import zmq.eventloop.zmqstream
+import tornado.ioloop
 import threading
 import ipc
 import numpy
@@ -18,13 +19,15 @@ import logging
 from utils.cmdline_args import argparser as _argparser
 
 eventLimit = 125
-zmq.eventloop.ioloop.install()
+
 # Tornado 5 changed the behaviour of IOLoop.instance() such that
 # is now returns a new thread local IOLoop instead of the main
 # thread IOLoop. So we need this global variable to tell the thread
 # the correct IOLoop to start.
 # http://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.instance
-ioloop = zmq.eventloop.ioloop.IOLoop.instance()
+#
+# IOLoop.instance() is depricated in Tornado 5.0. Use IOLoop.current() instead.
+ioloop = tornado.ioloop.IOLoop.current()
 
 class ZmqServer(object):
     """Implements the server that broadcasts the results from the backend.


### PR DESCRIPTION
This replace `pyzmq.eventloop.ioloop` with `tornado.ioloop`.

`eventloop.ioloop` since  is deprecated in `pyzmq` 17 and was removed in `pyzmq` 25 (released 12.01.2023)

This should work with `tornado` 3.0.0 (released in 2013) or later