### PR TITLE
Update euxfel backend

### DIFF
--- a/src/backend/euxfel.py
+++ b/src/backend/euxfel.py
@@ -121,6 +121,7 @@ class EUxfelTranslator(object):
         self._s2c = {}
         self._s2c["SPB_DET_AGIPD1M-1/CAL/APPEND_CORRECTED"] = "AGIPD"
         self._s2c["SPB_DET_AGIPD1M-1/CAL/APPEND_RAW"] = "AGIPD"
+        self._s2c["SPB_DET_AGIPD1M-1/DET/STACKED:xtdf"] = "AGIPD"
 
         for module in range(16):
             self._s2c["SPB_DET_AGIPD1M-1/DET/%dCH0:xtdf" % module] = ("AGIPD%02d" % module)

--- a/src/backend/euxfel.py
+++ b/src/backend/euxfel.py
@@ -64,7 +64,7 @@ class EUxfelTranslator(object):
             first_cell = state['EuXFEL/FirstCell']
 
         # Option to set the last cell to be selected per train
-        last_cell = -1
+        last_cell = MAX_TRAIN_LENGTH
         if 'EuXFEL/LastCell' in state:
             last_cell = state['EuXFEL/LastCell'] + 1
 

--- a/src/backend/euxfel.py
+++ b/src/backend/euxfel.py
@@ -175,7 +175,7 @@ class EUxfelTranslator(object):
         if(self._slow_client is not None): 
             buf, meta = self.append_slow_data(buf, meta)
        
-        age = numpy.floor(time.time()) - int(meta[list(meta.keys())[0]]['timestamp.tid'])
+        age = time.time() - meta[list(meta.keys())[0]]['timestamp']
         if self._max_train_age is None or age < self._max_train_age:
             return buf, meta
         else:

--- a/src/backend/euxfel.py
+++ b/src/backend/euxfel.py
@@ -157,7 +157,8 @@ class EUxfelTranslator(object):
         if(self._slow_client is not None): 
             buf, meta = self.append_slow_data(buf, meta)
        
-        age = time.time() - meta[list(meta.keys())[0]]['timestamp']
+        age = time.time()
+        age -= meta[list(meta.keys())[0]].get('timestamp', age)
         if self._max_train_age is None or age < self._max_train_age:
             return buf, meta
         else:

--- a/src/backend/euxfel.py
+++ b/src/backend/euxfel.py
@@ -406,15 +406,17 @@ class EUxfelTrainTranslator(EUxfelTranslator):
             timestamp = numpy.asarray(time.time())
 
         if 'image.pulseId' in obj:
-            train_length = numpy.array(obj["image.pulseId"]).shape[-1]
+            pulseid = numpy.squeeze(obj["image.pulseId"]).astype(int)
+            cellid = numpy.squeeze(obj['image.cellId']).astype(int)
+            train_length = len(pulseid)
             cells = self._cell_filter[:train_length]
-            pulseid  = numpy.array(obj["image.pulseId"][..., cells], dtype='int')
+            pulseid = pulseid[cells]
             # The denominator here is totally arbitrary, just we have different timestamps for different pulses
             timestamp = timestamp + (pulseid / 27000.)
             rec = Record('Timestamp', timestamp, ureg.s)
             rec.pulseId = pulseid
-            rec.cellId   = numpy.array(obj['image.cellId'][...,  cells], dtype='int')
-            rec.badCells = numpy.array(obj['image.cellId'][..., ~cells], dtype='int')
+            rec.cellId   = cellid[cells]
+            rec.badCells = cellid[~cells]
             rec.timestamp = timestamp
         else:
             rec = Record('Timestamp', timestamp, ureg.s)


### PR DESCRIPTION
This fixes up small things in euxfel backend:

- estimate train age by `timestamp` instead of `trainId`, or set age to zero if there is no timestamp in data
- fix `cellId`/`pulseId` shape by squeezing 1-element dimensions
- use `cellId` instead of cell position to filter bad cells
- fix `LastCell` defaults
- refactor reading of settings from `state` by using `dict.get()` to apply defaults