### PR TITLE
numpy 2.x compatibility

### DIFF
--- a/hummingbird/interface/data_source.py
+++ b/hummingbird/interface/data_source.py
@@ -225,8 +225,7 @@ class DataSource(QtCore.QObject):
         if(cmd == 'new_data'):
             data_x = payload[4]
             # At the moment x is always a timestamp so I'll add some metadata to show it
-            if type(data_x) is not numpy.ndarray:
-                data_x = numpy.array(data_x)
+            data_x = numpy.asarray(data_x)
             data_x.dtype = numpy.dtype(data_x.dtype, metadata={'units': 's'})
 
             conf = payload[5]

--- a/hummingbird/interface/ui/image_window.py
+++ b/hummingbird/interface/ui/image_window.py
@@ -464,7 +464,7 @@ class ImageWindow(DataWindow, Ui_imageWindow):
                 hmax   = img.shape[1]
                 length = pd.maxlen
             else:
-                img = numpy.array(pd_y, copy=False)
+                img = numpy.asarray(pd_y)
             self._configure_axis(source, title)
             transform = self._image_transform(img, source, title)
             

--- a/hummingbird/interface/ui/image_window.py
+++ b/hummingbird/interface/ui/image_window.py
@@ -455,10 +455,10 @@ class ImageWindow(DataWindow, Ui_imageWindow):
             elif conf["data_type"] == "vector":
                 #print(pd.y.shape)
                 if len(pd.y.shape) == 3:
-                    img = numpy.array(pd.y[:,1,:], copy=False)
+                    img = numpy.asarray(pd.y[:,1,:])
                 else:
-                    img = numpy.array(pd.y[:,:], copy=False)
-                #img = numpy.array(pd.y[:,1,:], copy=False)
+                    img = numpy.asarray(pd.y[:,:])
+                #img = numpy.asarray(pd.y[:,1,:])
                 bins   = img.shape[1]
                 hmin   = 0
                 hmax   = img.shape[1]
@@ -485,8 +485,8 @@ class ImageWindow(DataWindow, Ui_imageWindow):
                     auto_rage = True
                     auto_histogram = True
                 if "data_type" in conf and conf["data_type"] == "triple":
-                    triples = numpy.array(pd.y, copy=False)
-                    times   = numpy.array(pd.x, copy=False)
+                    triples = numpy.asarray(pd.y)
+                    times   = numpy.asarray(pd.x)
                     img, transform, x, y = self._fill_meanmap(times, triples,
                                                               xmin=conf["xmin"], xmax=conf["xmax"], ymin=conf["ymin"], ymax=conf["ymax"],
                                                               ybins=conf["ybins"], xbins=conf["xbins"],

--- a/hummingbird/interface/ui/plot_window.py
+++ b/hummingbird/interface/ui/plot_window.py
@@ -40,7 +40,7 @@ class Histogram(object):
         current_index = ringbuffer.number_of_added_elements
         number_of_values_to_add = current_index-self._last_add_index
         if number_of_values_to_add > 0:
-            values = numpy.array(ringbuffer, copy=False)[-(current_index-self._last_add_index):]
+            values = numpy.asarray(ringbuffer)[-(current_index-self._last_add_index):]
         else:
             return
         for this_value in values:
@@ -75,8 +75,8 @@ class NormalizedHistogram(Histogram):
         current_index = ringbuffer.number_of_added_elements
         number_of_values_to_add = (current_index-self._last_add_index)
         if number_of_values_to_add > 0:
-            values = numpy.array(ringbuffer, copy=False)[-number_of_values_to_add:, 0]
-            weights = numpy.array(ringbuffer, copy=False)[-number_of_values_to_add:, 1]
+            values = numpy.asarray(ringbuffer)[-number_of_values_to_add:, 0]
+            weights = numpy.asarray(ringbuffer)[-number_of_values_to_add:, 1]
         else:
             return
         for this_value, this_weight in zip(values, weights):
@@ -320,7 +320,7 @@ class PlotWindow(DataWindow, Ui_plotWindow):
                 symbol_size = 3
             pd_x,pd_y,pd_l = pd.snapshot()
             if(source.data_type[title] == 'scalar') or (source.data_type[title] == 'running_hist'):
-                y = numpy.array(pd_y, copy=False)
+                y = numpy.asarray(pd_y)
                 self.last_vector_y = {}
                 self.last_vector_x = None
             elif(source.data_type[title] == 'tuple'):
@@ -356,7 +356,7 @@ class PlotWindow(DataWindow, Ui_plotWindow):
                 symbol_size  = 8
             elif source.data_type[title] == 'vector':
                 if(self.current_index == -1):
-                    y = numpy.array(pd_y[self.current_index % pd_y.shape[0]], copy=False)
+                    y = numpy.asarray(pd_y[self.current_index % pd_y.shape[0]])
                     self.last_vector_y[title] = numpy.array(pd_y)
                     self.last_vector_x = numpy.array(pd_x)
                 else:
@@ -375,7 +375,7 @@ class PlotWindow(DataWindow, Ui_plotWindow):
                 
             x = None
             if(source.data_type[title] == 'scalar') or (source.data_type[title] == 'running_hist'):
-                x = numpy.array(pd_x, copy=False)
+                x = numpy.asarray(pd_x)
                 sorted_x = numpy.argsort(x)
                 x = x[sorted_x]
                 y = y[sorted_x]
@@ -481,9 +481,9 @@ class PlotWindow(DataWindow, Ui_plotWindow):
                     if eval('self._settings_diag.trendVector_%s.isChecked()' %trend):
                         _trend = getattr(numpy, trend)
                         if len(pd_y.shape) == 3:
-                            ytrend = _trend(numpy.array(pd_y[:,1,:], copy=False), axis=0)
+                            ytrend = _trend(numpy.asarray(pd_y[:,1,:]), axis=0)
                         else:
-                            ytrend = _trend(numpy.array(pd_y, copy=False), axis=0)
+                            ytrend = _trend(numpy.asarray(pd_y), axis=0)
                         plt_trend = self.plot.plot(x=x, y=ytrend, clear=False, pen=self.line_colors[color_index % len(self.line_colors)], symbol=symbol,
                                                    symbolPen=symbol_pen, symbolBrush=symbol_brush, symbolSize=symbol_size)
                         self.legend.addItem(plt_trend, trend)


### PR DESCRIPTION
This fixes an exception on image replot:
```
Traceback (most recent call last):
  File "/home/spbop/hummingbird/hummingbird/interface/gui.py", line 223, in _replot
    p.replot()
  File "/home/spbop/hummingbird/hummingbird/interface/ui/image_window.py", line 467, in replot
    img = numpy.array(pd_y, copy=False)
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```